### PR TITLE
Various updates

### DIFF
--- a/indra_db_lite/api.py
+++ b/indra_db_lite/api.py
@@ -652,7 +652,7 @@ def get_mesh_terms_for_grounding(
 
 def get_text_sample(
         num_samples: int, text_types: Optional[Collection[str]] = None
-):
+) -> TextContent:
     """Generate a random sample of texts of specified text types.
 
     Parameters
@@ -666,6 +666,11 @@ def get_text_sample(
         be included. Sample is generated only from entries in the indra lite
         database for which the best piece of content is one of the specified
         text types.
+
+    Returns
+    -------
+    py:class:`indra_db_lite.api.TextContent`
+        A TextContent object of unprocessed text content (lists of paragraphs).
     """
     if text_types is None:
         text_types = ('fulltext', 'abstract', 'title')

--- a/indra_db_lite/construction/assemble.py
+++ b/indra_db_lite/construction/assemble.py
@@ -109,15 +109,22 @@ def add_indices_to_mesh_pmids_table(sqlite_db_path) -> None:
 
 
 def add_indices_to_mesh_xrefs_table(sqlite_db_path) -> None:
-    query = """--
+    query1 = """--
     CREATE INDEX IF NOT EXISTS
         mesh_xrefs_curie_idx
     ON
         mesh_xrefs(curie)
     """
+    query2 = """--
+    CREATE INDEX IF NOT EXISTS
+        mesh_xrefs_mesh_num_is_concept_idx
+    ON
+        mesh_xrefs(mesh_num, is_concept)
+    """
     with closing(sqlite3.connect(sqlite_db_path)) as conn:
         with closing(conn.cursor()) as cur:
-            cur.execute(query)
+            for query in query1, query2:
+                cur.execute(query)
         conn.commit()
 
 

--- a/indra_db_lite/construction/assemble.py
+++ b/indra_db_lite/construction/assemble.py
@@ -24,15 +24,22 @@ from .util import get_sqlite_tables
 
 def add_indices_to_best_content_table(sqlite_db_path: str) -> None:
     """Make queries to best content table more efficient."""
-    query = """--
+    query1 = """--
     CREATE INDEX IF NOT EXISTS
         best_content_text_ref_id_idx
     ON
         best_content(text_ref_id)
     """
+    query2 = """--
+    CREATE INDEX IF NOT EXISTS
+        best_content_text_type_id_idx
+    ON
+        best_content(text_type)
+    """
     with closing(sqlite3.connect(sqlite_db_path)) as conn:
         with closing(conn.cursor()) as cur:
-            cur.execute(query)
+            for query in query1, query2:
+                cur.execute(query)
         conn.commit()
 
 

--- a/indra_db_lite/download.py
+++ b/indra_db_lite/download.py
@@ -33,13 +33,13 @@ def decompress_local_db(
     os.rename(compressed_db_path[:-3], outpath)
 
 
-def local_db_to_s3(
-        compressed_sqlite_db_path: str,
+def upload_to_s3(
+        path: str,
         bucket: str = locations.S3_BUCKET,
         key: str = locations.S3_KEY,
 ) -> None:
     client = boto3.client('s3')
-    client.upload_file(compressed_sqlite_db_path, bucket, key)
+    client.upload_file(path, bucket, key)
 
 
 def download_local_db_from_s3(

--- a/indra_db_lite/download.py
+++ b/indra_db_lite/download.py
@@ -12,25 +12,25 @@ from indra_db_lite import locations
 logger = logging.getLogger(__file__)
 
 
-def compress_local_db(sqlite_db_path: str, n_threads=1) -> None:
+def xz_compress(path: str, n_threads=1) -> None:
     assert isinstance(n_threads, int)
     thread_flag = "" if n_threads == 1 else f"-T{n_threads}"
     subprocess.run(
-        ["xz", "-v", "-1", thread_flag, sqlite_db_path]
+        ["xz", "-v", "-1", thread_flag, path]
     )
 
 
-def decompress_local_db(
-        compressed_db_path: str, outpath: str
+def xz_decompress(
+        compressed_path: str, outpath: str
 ) -> None:
     subprocess.run(
-        ["xz", "-v", "--decompress", "-1", compressed_db_path]
+        ["xz", "-v", "--decompress", "-1", compressed_path]
     )
     #  xz will not decompress if the file extension is not .xz. It's output
     # will have the same name as the input with the extension chopped off.
     # We can therefore assume that chopping off the last three characters
     # will give the correct path to the output of xz.
-    os.rename(compressed_db_path[:-3], outpath)
+    os.rename(compressed_path[:-3], outpath)
 
 
 def upload_to_s3(
@@ -52,7 +52,7 @@ def download_local_db_from_s3(
     with open(outpath + '.xz', 'wb') as f:
         client.download_fileobj(bucket, key, f)
     logger.info("Decompressing local db.")
-    decompress_local_db(outpath + '.xz', outpath)
+    xz_decompress(outpath + '.xz', outpath)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR updates functions in the API that make queries based on lists of text_ref_ids, or pmids to work around the limit on the number of ? variables allowed in an sqlite query. The offending functions were `get_text_ref_ids_for_pmids`, `get_pmids_for_text_ref_ids`, and `get_paragraphs_for_text_ref_ids`.

A function has been added to the API that generates a random sample of text content from the local database. An index on `mesh_num`, and `is_concept`, has been added to the `mesh_xrefs` table to facilitate a join used in a query to get all mesh terms with a uniprot mapping for help in constructing the background dictionary corpus.