### PR TITLE
Add function for PMID-based text retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ take over an hour to download and decompress the db file. Once completed,
 indra_db_lite should be ready to use.
 
 
-Run each script in construct/tables separately
-and then run construct/assembly
+## Construction
+Run each script in construct/tables separately and then run construct/assembly.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ take over an hour to download and decompress the db file. Once completed,
 indra_db_lite should be ready to use.
 
 
+Run each script in construct/tables separately
+and then run construct/assembly


### PR DESCRIPTION
This PR adds a convenience function to get text content directly from PMIDs without having to convert to TRIDs first.